### PR TITLE
Simplify read/write unaligned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 bitflags = "2.9.0"
 libc = "0.2.175"
+unaligned = "0.1.1"

--- a/src/mdb_macos_64bit_m1.rs
+++ b/src/mdb_macos_64bit_m1.rs
@@ -6381,15 +6381,13 @@ unsafe extern "C" fn mdb_cursor_next(
             (*mc).mc_flags.toggle(CursorFlags::C_DEL);
         } else if ((*mc).mc_ki[(*mc).mc_top as usize] as std::ffi::c_uint)
             .wrapping_add(1 as std::ffi::c_uint)
-            >= (std::ptr::read_unaligned(
-                (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_lower) as isize) as *mut u16,
-            ) as std::ffi::c_uint)
-                .wrapping_sub((16 as std::ffi::c_uint).wrapping_sub(if 0 as std::ffi::c_int != 0 {
+            >= (Unaligned::from_ptr(mp as *const MDB_page2).get().mp2_lower as u32).wrapping_sub(
+                (16 as std::ffi::c_uint).wrapping_sub(if 0 as std::ffi::c_int != 0 {
                     16 as std::ffi::c_uint
                 } else {
                     0 as std::ffi::c_uint
-                }))
-                >> 1 as std::ffi::c_int
+                }),
+            ) >> 1 as std::ffi::c_int
         {
             rc = mdb_cursor_sibling(mc, 1);
             if rc != 0 {
@@ -6402,11 +6400,7 @@ unsafe extern "C" fn mdb_cursor_next(
                 ((*mc).mc_ki[(*mc).mc_top as usize]).wrapping_add(1);
             (*mc).mc_ki[(*mc).mc_top as usize];
         }
-        if std::ptr::read_unaligned(
-            (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_flags) as isize) as *mut u16,
-        ) as std::ffi::c_int
-            & 0x20 as std::ffi::c_int
-            == 0x20 as std::ffi::c_int
+        if Unaligned::from_ptr(mp as *const MDB_page2).get().mp2_flags.contains(PageFlags::P_LEAF2)
         {
             (*key).mv_size = (*(*mc).mc_db).md_pad as size_t;
             (*key).mv_data = (mp as *mut std::ffi::c_char)
@@ -6415,12 +6409,7 @@ unsafe extern "C" fn mdb_cursor_next(
                 as *mut std::ffi::c_void;
             return MDB_SUCCESS;
         }
-        if std::ptr::read_unaligned(
-            (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_flags) as isize) as *mut u16,
-        ) as std::ffi::c_int
-            & 0x2 as std::ffi::c_int
-            == 0x2 as std::ffi::c_int
-        {
+        if Unaligned::from_ptr(mp as *const MDB_page2).get().mp2_flags.contains(PageFlags::P_LEAF) {
         } else {
             mdb_assert_fail(
                 (*(*mc).mc_txn).mt_env,
@@ -6642,7 +6631,7 @@ unsafe extern "C" fn mdb_cursor_set(
             let mut nodekey: MDB_val =
                 MDB_val { mv_size: 0, mv_data: std::ptr::null_mut::<std::ffi::c_void>() };
             mp = (*mc).mc_pg[(*mc).mc_top as usize];
-            if (std::ptr::read_unaligned(mp as *mut MDB_page2).mp2_lower as std::ffi::c_uint)
+            if (Unaligned::from_ptr(mp as *const MDB_page2).get().mp2_lower as std::ffi::c_uint)
                 .wrapping_sub((16 as std::ffi::c_uint).wrapping_sub(if 0 as std::ffi::c_int != 0 {
                     16 as std::ffi::c_uint
                 } else {
@@ -6654,11 +6643,10 @@ unsafe extern "C" fn mdb_cursor_set(
                 (*mc).mc_ki[(*mc).mc_top as usize] = 0 as indx_t;
                 return MDB_NOTFOUND;
             }
-            if std::ptr::read_unaligned(
-                (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_flags) as isize) as *mut u16,
-            ) as std::ffi::c_int
-                & 0x20 as std::ffi::c_int
-                != 0
+            if Unaligned::from_ptr(mp as *const MDB_page2)
+                .get()
+                .mp2_flags
+                .intersects(PageFlags::P_LEAF2)
             {
                 nodekey.mv_size = (*(*mc).mc_db).md_pad as size_t;
                 nodekey.mv_data = (mp as *mut std::ffi::c_char)
@@ -7053,12 +7041,10 @@ unsafe extern "C" fn mdb_cursor_first(
                 return rc;
             }
         }
-        if std::ptr::read_unaligned(
-            ((*mc).mc_pg[(*mc).mc_top as usize] as *mut u8)
-                .offset(offset_of!(MDB_page2, mp2_flags) as isize) as *mut u16,
-        ) as std::ffi::c_int
-            & 0x2 as std::ffi::c_int
-            == 0x2 as std::ffi::c_int
+        if Unaligned::from_ptr((*mc).mc_pg[(*mc).mc_top as usize] as *const MDB_page2)
+            .get()
+            .mp2_flags
+            .contains(PageFlags::P_LEAF)
         {
         } else {
             mdb_assert_fail(
@@ -7088,12 +7074,10 @@ unsafe extern "C" fn mdb_cursor_first(
         (*mc).mc_flags.insert(CursorFlags::C_INITIALIZED);
         (*mc).mc_flags.remove(CursorFlags::C_EOF);
         (*mc).mc_ki[(*mc).mc_top as usize] = 0 as indx_t;
-        if std::ptr::read_unaligned(
-            ((*mc).mc_pg[(*mc).mc_top as usize] as *mut u8)
-                .offset(offset_of!(MDB_page2, mp2_flags) as isize) as *mut u16,
-        ) as std::ffi::c_int
-            & 0x20 as std::ffi::c_int
-            == 0x20 as std::ffi::c_int
+        if Unaligned::from_ptr((*mc).mc_pg[(*mc).mc_top as usize] as *const MDB_page2)
+            .get()
+            .mp2_flags
+            .contains(PageFlags::P_LEAF2)
         {
             if !key.is_null() {
                 (*key).mv_size = (*(*mc).mc_db).md_pad as size_t;
@@ -8155,11 +8139,8 @@ unsafe extern "C" fn _mdb_cursor_put(
                             15483849737692682886 => {}
                             1849955825383499200 => {}
                             _ => {
-                                fp_flags = std::ptr::read_unaligned(
-                                    (fp as *mut u8)
-                                        .offset(offset_of!(MDB_page2, mp2_flags) as isize)
-                                        as *mut PageFlags,
-                                );
+                                fp_flags =
+                                    Unaligned::from_ptr(fp as *const MDB_page2).get().mp2_flags;
                                 if (8 as std::ffi::c_ulong)
                                     .wrapping_add((*leaf).mn_ksize as std::ffi::c_ulong)
                                     .wrapping_add(xdata.mv_size)
@@ -8350,26 +8331,17 @@ unsafe extern "C" fn _mdb_cursor_put(
                     (*(mp as *mut MDB_page2)).mp2_flags.insert(PageFlags::P_DIRTY);
                     std::ptr::write_unaligned(
                         (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_pad) as isize) as *mut u16,
-                        std::ptr::read_unaligned(
-                            (fp as *mut u8).offset(offset_of!(MDB_page2, mp2_pad) as isize)
-                                as *mut u16,
-                        ),
+                        Unaligned::from_ptr(fp as *const MDB_page2).get().mp2_pad,
                     );
                     std::ptr::write_unaligned(
                         (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_lower) as isize)
                             as *mut indx_t,
-                        std::ptr::read_unaligned(
-                            (fp as *mut u8).offset(offset_of!(MDB_page2, mp2_lower) as isize)
-                                as *mut indx_t,
-                        ),
+                        Unaligned::from_ptr(fp as *const MDB_page2).get().mp2_lower,
                     );
                     std::ptr::write_unaligned(
                         (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_upper) as isize)
                             as *mut indx_t,
-                        (std::ptr::read_unaligned(
-                            (fp as *mut u8).offset(offset_of!(MDB_page2, mp2_upper) as isize)
-                                as *mut indx_t,
-                        ) as std::ffi::c_uint)
+                        (Unaligned::from_ptr(fp as *const MDB_page2).get().mp2_upper as u32)
                             .wrapping_add(offset) as indx_t,
                     );
                     if fp_flags.intersects(PageFlags::P_LEAF2) {
@@ -8400,12 +8372,10 @@ unsafe extern "C" fn _mdb_cursor_put(
                                     }) as isize,
                                 ) as *mut std::ffi::c_void,
                             (fp as *mut std::ffi::c_char)
-                                .offset(std::ptr::read_unaligned(
-                                    (fp as *mut u8)
-                                        .offset(offset_of!(MDB_page2, mp2_upper) as isize)
-                                        as *mut indx_t,
-                                ) as std::ffi::c_int
-                                    as isize)
+                                .offset(
+                                    Unaligned::from_ptr(fp as *const MDB_page2).get().mp2_upper
+                                        as isize,
+                                )
                                 .offset(
                                     (if 0 as std::ffi::c_int != 0 {
                                         16 as std::ffi::c_uint
@@ -8414,11 +8384,10 @@ unsafe extern "C" fn _mdb_cursor_put(
                                     }) as isize,
                                 ) as *const std::ffi::c_void,
                             (olddata.mv_size)
-                                .wrapping_sub(std::ptr::read_unaligned(
-                                    (fp as *mut u8)
-                                        .offset(offset_of!(MDB_page2, mp2_upper) as isize)
-                                        as *mut indx_t,
-                                ) as size_t)
+                                .wrapping_sub(
+                                    Unaligned::from_ptr(fp as *const MDB_page2).get().mp2_upper
+                                        as u64,
+                                )
                                 .wrapping_sub(
                                     (if 0 as std::ffi::c_int != 0 {
                                         16 as std::ffi::c_uint
@@ -8430,9 +8399,9 @@ unsafe extern "C" fn _mdb_cursor_put(
                         memcpy(
                             (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_ptrs) as isize) as *mut std::ffi::c_void,
                             (fp as *mut u8).offset(offset_of!(MDB_page2, mp2_ptrs) as isize) as *const std::ffi::c_void,
-                            (((std::ptr::read_unaligned(
-                                (fp as *mut u8).offset(offset_of!(MDB_page2, mp2_lower) as isize) as *mut indx_t
-                            ) as std::ffi::c_uint)
+                            (((Unaligned::from_ptr(
+                                fp as *const MDB_page2).get().mp2_lower as u32
+                            )
                                 .wrapping_sub((16 as std::ffi::c_uint).wrapping_sub(
                                     if 0 as std::ffi::c_int != 0 {
                                         16 as std::ffi::c_uint
@@ -8445,10 +8414,8 @@ unsafe extern "C" fn _mdb_cursor_put(
                         );
                         i = 0 as std::ffi::c_uint;
                         while i
-                            < (std::ptr::read_unaligned(
-                                (fp as *mut u8).offset(offset_of!(MDB_page2, mp2_lower) as isize)
-                                    as *mut indx_t,
-                            ) as std::ffi::c_uint)
+                            < (Unaligned::from_ptr(fp as *const MDB_page2).get().mp2_lower
+                                as std::ffi::c_uint)
                                 .wrapping_sub((16 as std::ffi::c_uint).wrapping_sub(
                                     if 0 as std::ffi::c_int != 0 {
                                         16 as std::ffi::c_uint
@@ -8479,23 +8446,22 @@ unsafe extern "C" fn _mdb_cursor_put(
                         | 0x2 as std::ffi::c_int
                         | 0x10000 as std::ffi::c_int
                         | 0x20000 as std::ffi::c_int) as std::ffi::c_uint;
-                nsize = if std::ptr::read_unaligned(
-                    (*mc).mc_pg[(*mc).mc_top as usize] as *mut MDB_page2,
-                )
-                .mp2_flags
-                .contains(PageFlags::P_LEAF2)
-                {
-                    (*key).mv_size
-                } else {
-                    mdb_leaf_size(env, key, rdata)
-                };
-                if ((std::ptr::read_unaligned((*mc).mc_pg[(*mc).mc_top as usize] as *mut MDB_page2)
+                nsize =
+                    if Unaligned::from_ptr((*mc).mc_pg[(*mc).mc_top as usize] as *const MDB_page2)
+                        .get()
+                        .mp2_flags
+                        .contains(PageFlags::P_LEAF2)
+                    {
+                        (*key).mv_size
+                    } else {
+                        mdb_leaf_size(env, key, rdata)
+                    };
+                if ((Unaligned::from_ptr((*mc).mc_pg[(*mc).mc_top as usize] as *const MDB_page2)
+                    .get()
                     .mp2_upper as std::ffi::c_int
-                    - std::ptr::read_unaligned(
-                        (*mc).mc_pg[(*mc).mc_top as usize] as *mut std::ffi::c_void
-                            as *mut MDB_page2,
-                    )
-                    .mp2_lower as std::ffi::c_int) as size_t)
+                    - Unaligned::from_ptr((*mc).mc_pg[(*mc).mc_top as usize] as *const MDB_page2)
+                        .get()
+                        .mp2_lower as std::ffi::c_int) as size_t)
                     < nsize
                 {
                     if flags & (0x4 as std::ffi::c_int | 0x2 as std::ffi::c_int) as std::ffi::c_uint
@@ -9167,8 +9133,8 @@ unsafe extern "C" fn mdb_node_add(
         let mut mp: *mut MDB_page = (*mc).mc_pg[(*mc).mc_top as usize];
         let mut ofp: *mut MDB_page = std::ptr::null_mut::<MDB_page>();
         let mut ndata: *mut std::ffi::c_void = std::ptr::null_mut::<std::ffi::c_void>();
-        if std::ptr::read_unaligned(mp as *mut MDB_page2).mp2_upper as std::ffi::c_int
-            >= std::ptr::read_unaligned(mp as *mut MDB_page2).mp2_lower as std::ffi::c_int
+        if Unaligned::from_ptr(mp as *const MDB_page2).get().mp2_upper as i32
+            >= Unaligned::from_ptr(mp as *const MDB_page2).get().mp2_lower as i32
         {
         } else {
             mdb_assert_fail(
@@ -9180,7 +9146,7 @@ unsafe extern "C" fn mdb_node_add(
                 8408 as std::ffi::c_int,
             );
         };
-        if std::ptr::read_unaligned(mp as *mut MDB_page2).mp2_flags.contains(PageFlags::P_LEAF2) {
+        if Unaligned::from_ptr(mp as *mut MDB_page2).get().mp2_flags.contains(PageFlags::P_LEAF2) {
             let mut ksize: std::ffi::c_int = (*(*mc).mc_db).md_pad as std::ffi::c_int;
             let mut dif: std::ffi::c_int = 0;
             let mut ptr: *mut std::ffi::c_char = (mp as *mut std::ffi::c_char)
@@ -9213,14 +9179,14 @@ unsafe extern "C" fn mdb_node_add(
             ) as indx_t;
             return MDB_SUCCESS;
         }
-        room = (std::ptr::read_unaligned(mp as *mut MDB_page2).mp2_upper as std::ffi::c_int
-            - std::ptr::read_unaligned(mp as *mut MDB_page2).mp2_lower as std::ffi::c_int)
+        room = (Unaligned::from_ptr(mp as *mut MDB_page2).get().mp2_upper as i32
+            - Unaligned::from_ptr(mp as *mut MDB_page2).get().mp2_lower as i32)
             as ssize_t
             - ::core::mem::size_of::<indx_t>() as ssize_t;
         if !key.is_null() {
             node_size = node_size.wrapping_add((*key).mv_size);
         }
-        if std::ptr::read_unaligned(mp as *mut MDB_page2).mp2_flags.contains(PageFlags::P_LEAF) {
+        if Unaligned::from_ptr(mp as *mut MDB_page2).get().mp2_flags.contains(PageFlags::P_LEAF) {
             if !key.is_null() && !data.is_null() {
             } else {
                 mdb_assert_fail(
@@ -9283,8 +9249,7 @@ unsafe extern "C" fn mdb_node_add(
                 MDB_PAGE_FULL
             }
             _ => {
-                i = ((std::ptr::read_unaligned(mp as *mut MDB_page2)).mp2_lower
-                    as std::ffi::c_uint)
+                i = ((Unaligned::from_ptr(mp as *const MDB_page2)).get().mp2_lower as u32)
                     .wrapping_sub((16 as std::ffi::c_uint).wrapping_sub(
                         if 0 as std::ffi::c_int != 0 {
                             16 as std::ffi::c_uint
@@ -9306,10 +9271,10 @@ unsafe extern "C" fn mdb_node_add(
                     );
                     i = i.wrapping_sub(1);
                 }
-                ofs = ((std::ptr::read_unaligned(mp as *mut MDB_page2)).mp2_upper as size_t)
+                ofs = (Unaligned::from_ptr(mp as *const MDB_page2).get().mp2_upper as size_t)
                     .wrapping_sub(node_size) as indx_t;
                 if ofs as std::ffi::c_ulong
-                    >= ((std::ptr::read_unaligned(mp as *mut MDB_page2)).mp2_lower
+                    >= (Unaligned::from_ptr(mp as *const MDB_page2).get().mp2_lower
                         as std::ffi::c_ulong)
                         .wrapping_add(::core::mem::size_of::<indx_t>() as std::ffi::c_ulong)
                 {
@@ -9337,7 +9302,8 @@ unsafe extern "C" fn mdb_node_add(
                 );
                 std::ptr::write_unaligned(
                     (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_lower) as isize) as *mut u16,
-                    std::ptr::read_unaligned(mp as *mut MDB_page2)
+                    Unaligned::from_ptr(mp as *const MDB_page2)
+                        .get()
                         .mp2_lower
                         .wrapping_add(::core::mem::size_of::<indx_t>() as u16),
                 );
@@ -9365,11 +9331,10 @@ unsafe extern "C" fn mdb_node_add(
                     flags as std::ffi::c_ushort,
                 );
 
-                if std::ptr::read_unaligned(
-                    (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_flags) as isize) as *mut u16,
-                ) as std::ffi::c_int
-                    & 0x2 as std::ffi::c_int
-                    == 0x2 as std::ffi::c_int
+                if Unaligned::from_ptr(mp as *const MDB_page2)
+                    .get()
+                    .mp2_flags
+                    .contains(PageFlags::P_LEAF)
                 {
                     std::ptr::write_unaligned(
                         (node as *mut u8).offset(offset_of!(MDB_node, mn_lo) as isize) as *mut u16,
@@ -9409,11 +9374,10 @@ unsafe extern "C" fn mdb_node_add(
                         (*key).mv_size,
                     );
                 }
-                if std::ptr::read_unaligned(
-                    (mp as *mut u8).offset(offset_of!(MDB_page2, mp2_flags) as isize) as *mut u16,
-                ) as std::ffi::c_int
-                    & 0x2 as std::ffi::c_int
-                    == 0x2 as std::ffi::c_int
+                if Unaligned::from_ptr(mp as *const MDB_page2)
+                    .get()
+                    .mp2_flags
+                    .contains(PageFlags::P_LEAF)
                 {
                     ndata = ((*node).mn_data)
                         .as_mut_ptr()
@@ -9733,16 +9697,14 @@ unsafe extern "C" fn mdb_xcursor_init1(mut mc: *mut MDB_cursor, mut node: *mut M
             (*mx).mx_db.md_branch_pages = 0 as pgno_t;
             (*mx).mx_db.md_leaf_pages = 1 as pgno_t;
             (*mx).mx_db.md_overflow_pages = 0 as pgno_t;
-            (*mx).mx_db.md_entries = ((std::ptr::read_unaligned::<MDB_page2>(fp as *mut MDB_page2)
-                .mp2_lower as std::ffi::c_uint)
-                .wrapping_sub((16 as std::ffi::c_uint).wrapping_sub(
-                    if 0 as std::ffi::c_int != 0 {
+            (*mx).mx_db.md_entries =
+                ((Unaligned::from_ptr(fp as *const MDB_page2).get().mp2_lower as u32).wrapping_sub(
+                    (16 as std::ffi::c_uint).wrapping_sub(if 0 as std::ffi::c_int != 0 {
                         16 as std::ffi::c_uint
                     } else {
                         0 as std::ffi::c_uint
-                    },
-                ))
-                >> 1 as std::ffi::c_int) as mdb_size_t;
+                    }),
+                ) >> 1 as std::ffi::c_int) as mdb_size_t;
 
             let mut s: *mut std::ffi::c_ushort = std::ptr::null_mut::<std::ffi::c_ushort>();
             let mut d: *mut std::ffi::c_ushort = std::ptr::null_mut::<std::ffi::c_ushort>();


### PR DESCRIPTION
This PR utilizes the _unaligned_ or other refactoring to simplify and remove the unaligned reads in the code. The goal is to make it easier to contribute to and understand the codebase.